### PR TITLE
Fix configuration initializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.gem
 *.rbc
 .bundle
+.rspec
+.rvmrc
 .config
 .yardoc
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gem 'tbk'
 Configure your commerce
 
 ```ruby
-TBK::configure do |config|
+TBK.configure do |config|
   config.commerce_id YOUR_COMMERCE_ID
   config.commerce_key YOUR_RSA_KEY
 end

--- a/lib/tbk/config.rb
+++ b/lib/tbk/config.rb
@@ -35,7 +35,7 @@ module TBK
   #     end
   #
   # @yield [TBK::Config] The config object
-  def configure(&block)
+  def self.configure(&block)
     yield(self.config)
     nil
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe TBK do
+
+  it "should respond to 'configure'" do
+    TBK.should respond_to :configure
+  end
+
+end

--- a/spec/support/syntax.rb
+++ b/spec/support/syntax.rb
@@ -2,4 +2,18 @@ RSpec.configure do |config|
   config.expect_with :rspec do |expect|
     expect.syntax = :expect
   end
+
+  # see https://github.com/rspec/rspec-expectations/blob/master/spec/spec_helper.rb
+  shared_context "with #should enabled", :uses_should do
+    orig_syntax = nil
+
+    before(:all) do
+      orig_syntax = RSpec::Matchers.configuration.syntax
+      RSpec::Matchers.configuration.syntax = [:expect, :should]
+    end
+
+    after(:all) do
+      RSpec::Matchers.configuration.syntax = orig_syntax
+    end
+  end
 end


### PR DESCRIPTION
The README recommends to use the following initializer:

``` ruby
TBK::configure do |config|
  config.commerce_id YOUR_COMMERCE_ID
  config.commerce_key YOUR_RSA_KEY
end
```

However, it triggers the following error:

```
... /config/initializers/tbk.rb:5:in `<top (required)>': undefined method `configure' for TBK:Module (NoMethodError)
```

On the other hand, in `lib/tbk/config.rb` the recommended initializer calls `TBK.configure` instead of `TBK::configure`. AS of, that call triggers the same error.
