### PR TITLE
Move confirmarion_url parameters to TBK.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Configure your commerce
 TBK.configure do |config|
   config.commerce_id YOUR_COMMERCE_ID
   config.commerce_key YOUR_RSA_KEY
+  config.confirmation_url_ip_address '127.0.0.1'
+  config.confirmation_url_port '80'
+  config.confirmation_url_protocol 'http'
 end
 ```
 
@@ -46,7 +49,10 @@ class WebpayController < ApplicationController
       order_id: ORDER_ID,
       success_url: webpay_success_url,
       # Webpay can only access the HTTP protocol to a direct IP address (keep that in mind)
-      confirmation_url: webpay_confirmation_url(host: SERVER_IP_ADDRESS, protocol: 'http'),
+      confirmation_url: webpay_confirmation_url(
+                              host: TBK.config.confirmation_url_ip_address,
+                              port: TBK.config.confirmation_url_port,
+                              protocol: TBK.config.confirmation_url_protocol),
 
       # Optionaly supply:
       session_id: SOME_SESSION_VALUE,

--- a/example/app/controllers/webpay_controller.rb
+++ b/example/app/controllers/webpay_controller.rb
@@ -10,7 +10,10 @@ class WebpayController < ApplicationController
       amount: 5000.0,
       order_id: SecureRandom.hex(6),
       success_url: webpay_success_url,
-      confirmation_url: webpay_confirmation_url(host: '127.0.0.1', port: 80, protocol: 'http'),
+      confirmation_url: webpay_confirmation_url(
+                              host: TBK.config.confirmation_url_ip_address,
+                              port: TBK.config.confirmation_url_port,
+                              protocol: TBK.config.confirmation_url_protocol),
       session_id: SecureRandom.hex(6),
       failure_url: webpay_failure_url # success_url is used by default
     })

--- a/example/config/application.rb
+++ b/example/config/application.rb
@@ -10,6 +10,9 @@ module Example
       config.environment :test
       config.commerce_id 597026007976
       # config.commerce_key SOME_RSA_KEY
+      config.confirmation_url_ip_address '127.0.0.1'
+      config.confirmation_url_port '80'
+      config.confirmation_url_protocol 'http'
     end
 
     # Configure the default encoding used in templates for Ruby 1.9.

--- a/lib/tbk/config.rb
+++ b/lib/tbk/config.rb
@@ -13,6 +13,24 @@ module TBK
       @key || ENV['TBK_COMMERCE_KEY']
     end
 
+    # Set and gets the default IP address of the confirmation URL
+    def confirmation_url_ip_address(ip_address = nil)
+      @ip_address = ip_address if ip_address
+      @ip_address || ENV['TBK_CONFIRMATION_URL_IP_ADDRESS']
+    end
+
+    # Set and gets the default port of the confirmation URL
+    def confirmation_url_port(port = nil)
+      @port = port if port
+      @port || ENV['TBK_CONFIRMATION_URL_PORT']
+    end
+
+    # Set and gets the default protocol for the confirmation URL
+    def confirmation_url_protocol(protocol = nil)
+      @protocol = protocol if protocol
+      @protocol || ENV['TBK_CONFIRMATION_URL_PROTOCOL']
+    end
+
     # Sets the default commerce environment
     # @return [Symbol] the default commerce environment
     def environment(environment = nil)


### PR DESCRIPTION
In order to avoid editing the `WebpayController` when switching from one server to another (typically from a local development environment to a remote one for production or QA), I moved the `confirmation_url` parameters to configuration variables.
