### PR TITLE
Se quita la verificación del SSL (fix temporal)

### DIFF
--- a/lib/tbk/webpay/payment.rb
+++ b/lib/tbk/webpay/payment.rb
@@ -82,7 +82,7 @@ module TBK
           until response && response['location'].nil?
             uri = URI.parse( response.nil? ? self.validation_url : response['location'] )
 
-            response = Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+            response = Net::HTTP.start(uri.host, uri.port) do |http|
               post = Net::HTTP::Post.new uri.path
               post["user-agent"] = "TBK/#{ TBK::VERSION::GEM } (Ruby/#{ RUBY_VERSION }; +#{ TBK::VERSION::WEBSITE })"
               post.set_form_data({

--- a/lib/tbk/webpay/payment.rb
+++ b/lib/tbk/webpay/payment.rb
@@ -82,7 +82,7 @@ module TBK
           until response && response['location'].nil?
             uri = URI.parse( response.nil? ? self.validation_url : response['location'] )
 
-            response = Net::HTTP.start(uri.host, uri.port) do |http|
+            response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
               post = Net::HTTP::Post.new uri.path
               post["user-agent"] = "TBK/#{ TBK::VERSION::GEM } (Ruby/#{ RUBY_VERSION }; +#{ TBK::VERSION::WEBSITE })"
               post.set_form_data({
@@ -93,7 +93,6 @@ module TBK
               })
 
               # http.read_timeout = Webpay::Config.timeout
-              http.verify_mode = OpenSSL::SSL::VERIFY_NONE
               http.request post
             end
           end

--- a/lib/tbk/webpay/payment.rb
+++ b/lib/tbk/webpay/payment.rb
@@ -82,7 +82,7 @@ module TBK
           until response && response['location'].nil?
             uri = URI.parse( response.nil? ? self.validation_url : response['location'] )
 
-            response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+            response = Net::HTTP.start(uri.host, uri.port, :use_ssl => true, :verify_mode => OpenSSL::SSL::VERIFY_NONE) do |http|
               post = Net::HTTP::Post.new uri.path
               post["user-agent"] = "TBK/#{ TBK::VERSION::GEM } (Ruby/#{ RUBY_VERSION }; +#{ TBK::VERSION::WEBSITE })"
               post.set_form_data({

--- a/lib/tbk/webpay/payment.rb
+++ b/lib/tbk/webpay/payment.rb
@@ -93,6 +93,7 @@ module TBK
               })
 
               # http.read_timeout = Webpay::Config.timeout
+              http.verify_mode = OpenSSL::SSL::VERIFY_NONE
               http.request post
             end
           end


### PR DESCRIPTION
como revisé en este issue https://github.com/sagmor/tbk/issues/28 transbank no tiene correctamente instalado su certficado en el subdominio https://webpay3g.transbank.cl mientras no arreglen esto, la gema no debería exigir verificación del SSL