### PR TITLE
Desabilitar SSL cuando es necesario

### DIFF
--- a/lib/tbk/config.rb
+++ b/lib/tbk/config.rb
@@ -19,6 +19,11 @@ module TBK
       @environment = environment if environment
       (@environment || ENV['TBK_COMMERCE_ENVIRONMENT'] || :production).to_sym
     end
+
+    def ssl_verify_mode(mode = nil)
+      @ssl_verify_mode = mode if mode
+      @ssl_verify_mode || OpenSSL::SSL::VERIFY_PEER
+    end
   end
 
   # Returns the configuration object

--- a/lib/tbk/webpay/payment.rb
+++ b/lib/tbk/webpay/payment.rb
@@ -82,7 +82,10 @@ module TBK
           until response && response['location'].nil?
             uri = URI.parse( response.nil? ? self.validation_url : response['location'] )
 
-            response = Net::HTTP.start(uri.host, uri.port, :use_ssl => true) do |http|
+            response = Net::HTTP.start(uri.host, uri.port,{
+              :use_ssl => true,
+              :verify_mode => TBK.config.ssl_verify_mode
+            }) do |http|
               post = Net::HTTP::Post.new uri.path
               post["user-agent"] = "TBK/#{ TBK::VERSION::GEM } (Ruby/#{ RUBY_VERSION }; +#{ TBK::VERSION::WEBSITE })"
               post.set_form_data({


### PR DESCRIPTION
La idea es poder desactivar SSL cuando Transbank se hecha los certificados.

Para solucionar #28 y #29

Basta con:

```ruby
TBK.configure do |config|
  # ...
  config.ssl_verify_mode OpenSSL::SSL::VERIFY_NONE
end

```