### PR TITLE
Fix official logger

### DIFF
--- a/lib/tbk/webpay/confirmation.rb
+++ b/lib/tbk/webpay/confirmation.rb
@@ -28,10 +28,12 @@ module TBK
       end
 
       def acknowledge
+        TBK::Webpay.logger.confirmation(self,'ACK')
         self.commerce.webpay_encrypt('ACK')
       end
 
       def reject
+        TBK::Webpay.logger.confirmation(self, 'ERR')
         self.commerce.webpay_encrypt('ERR')
       end
 
@@ -120,8 +122,6 @@ module TBK
             @params[key.to_sym] = CGI.unescape(value)
           end
           @params[:TBK_MAC] = decrypted_params[:signature]
-
-          TBK::Webpay.logger.confirmation(self)
 
           true
         end

--- a/lib/tbk/webpay/logger/base_logger.rb
+++ b/lib/tbk/webpay/logger/base_logger.rb
@@ -16,7 +16,7 @@ module TBK
         end
 
         # Abstract method to log a payment confirmation
-        def confirmation(confirmation)
+        def confirmation(confirmation, accept)
           raise NotImplementedError, "TBK::Webpay::Logger::BaseLogger subclass must implement #confirmation method"
         end
 

--- a/lib/tbk/webpay/logger/null_logger.rb
+++ b/lib/tbk/webpay/logger/null_logger.rb
@@ -6,7 +6,7 @@ module TBK
           # NoOp
         end
 
-        def confirmation(confirmation)
+        def confirmation(confirmation, accept)
           # NoOp
         end
       end

--- a/lib/tbk/webpay/logger/official_logger.rb
+++ b/lib/tbk/webpay/logger/official_logger.rb
@@ -44,7 +44,7 @@ module TBK
           end
         end
 
-        def confirmation(confirmation)
+        def confirmation(confirmation, accept)
           events_log_file do |file|
             file.write CONFIRMATION_FORMAT % {
               date: now.strftime(LOG_DATE_FORMAT),
@@ -59,7 +59,8 @@ module TBK
 
           bitacora_log_file do |file|
             file.write BITACORA_FORMAT % {'TBK_VCI' => ''}.merge(confirmation.params).merge({
-              commerce_id: confirmation.commerce.id
+              commerce_id: confirmation.commerce.id,
+              accept: accept
             })
           end
         end
@@ -149,7 +150,7 @@ EOF
 EOF
 
         BITACORA_FORMAT = %w{
-          ACK;
+          %<accept>s;
           TBK_ORDEN_COMPRA=%<TBK_ORDEN_COMPRA>s;
           TBK_CODIGO_COMERCIO=%<commerce_id>s;
           TBK_TIPO_TRANSACCION=%<TBK_TIPO_TRANSACCION>s;


### PR DESCRIPTION
El official_logger ahora agrega ERR a la bitácora si se rechazo la
transacción y ACK si se aceptó. 

La certificación requiere que la bitácora entregue esto.